### PR TITLE
Feat: Add Article View and Overhaul UI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -204,6 +204,8 @@ impl NostrStatusApp {
             show_zap_dialog: false,
             zap_amount_input: String::new(),
             zap_target_post: None,
+            viewing_article: None,
+            show_profile_menu: false,
         };
         let data = Arc::new(Mutex::new(app_data_internal));
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -116,6 +116,7 @@ pub enum ProfileSubView {
 pub enum AppTab {
     Home,
     Profile,
+    ArticleView,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Serialize, Deserialize)]
@@ -191,4 +192,8 @@ pub struct NostrStatusAppInternal {
     pub show_zap_dialog: bool,
     pub zap_amount_input: String,
     pub zap_target_post: Option<TimelinePost>,
+    // Article View
+    pub viewing_article: Option<TimelinePost>,
+    // UI State
+    pub show_profile_menu: bool,
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -5,6 +5,7 @@ pub mod profile_view;
 pub mod wallet_view;
 pub mod image_cache;
 pub mod zap;
+pub mod article_view;
 
 use eframe::egui::{self, Margin};
 // nostr v0.43.0 / nostr-sdk: RelayMetadata は nostr_sdk::nips::nip65 に移動したため import する
@@ -23,6 +24,8 @@ impl eframe::App for NostrStatusApp {
         // app_data_arc をクローンして非同期タスクに渡す
         let app_data_arc_clone = self.data.clone();
         let runtime_handle = self.runtime.handle().clone();
+
+        let mut urls_to_load: Vec<(String, ImageKind)> = Vec::new();
 
         let panel_frame = egui::Frame::default()
             .inner_margin(Margin::same(15))
@@ -102,54 +105,174 @@ impl eframe::App for NostrStatusApp {
                     .show_inside(ui, |ui| {
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                             if app_data.is_logged_in {
-                                ui.menu_button("👤", |ui| {
-                                    if ui.button("Profile").clicked() {
-                                        app_data.current_tab = AppTab::Profile;
-                                        app_data.current_profile_sub_view = ProfileSubView::Profile;
-                                        ui.close();
+                                let avatar_size = egui::vec2(40.0, 40.0); // Increased size
+                                let avatar_url = app_data.editable_profile.picture.clone();
+                                let image_state = if !avatar_url.is_empty() {
+                                    app_data.image_cache.get(&avatar_url).cloned()
+                                } else {
+                                    None
+                                };
+
+                                let response;
+                                match image_state {
+                                    Some(ImageState::Loaded(texture_handle)) => {
+                                        let img_button = egui::ImageButton::new(egui::Image::new(&texture_handle).max_size(avatar_size));
+                                        response = ui.add(img_button);
+                                    },
+                                    _ => {
+                                        if !avatar_url.is_empty() && !urls_to_load.iter().any(|(u, _)| u == &avatar_url) {
+                                            urls_to_load.push((avatar_url.clone(), ImageKind::Avatar));
+                                        }
+                                        let button = egui::Button::new("👤").min_size(avatar_size);
+                                        response = ui.add(button);
                                     }
-                                    if ui.button("Relays").clicked() {
-                                        app_data.current_tab = AppTab::Profile;
-                                        app_data.current_profile_sub_view = ProfileSubView::Relays;
-                                        ui.close();
+                                };
+
+                                if response.clicked() {
+                                    app_data.show_profile_menu = !app_data.show_profile_menu;
+                                }
+
+                                if app_data.show_profile_menu {
+                                    egui::Area::new("profile_menu_area".into())
+                                        .fixed_pos(response.rect.left_bottom())
+                                        .show(ctx, |ui| {
+                                            let frame = egui::Frame {
+                                                inner_margin: egui::Margin::same(10),
+                                                ..egui::Frame::menu(ui.style())
+                                            };
+                                            frame.show(ui, |ui| {
+                                                if ui.button("Profile").clicked() {
+                                                    app_data.current_tab = AppTab::Profile;
+                                                    app_data.current_profile_sub_view = ProfileSubView::Profile;
+                                                    app_data.show_profile_menu = false;
+                                                }
+                                                if ui.button("Relays").clicked() {
+                                                    app_data.current_tab = AppTab::Profile;
+                                                    app_data.current_profile_sub_view = ProfileSubView::Relays;
+                                                    app_data.show_profile_menu = false;
+                                                }
+                                                if ui.button("Wallet").clicked() {
+                                                    app_data.current_tab = AppTab::Profile;
+                                                    app_data.current_profile_sub_view = ProfileSubView::Wallet;
+                                                    app_data.show_profile_menu = false;
+                                                }
+                                            });
+                                        });
+
+                                    // Close menu if clicking outside
+                                    if ctx.input(|i| i.pointer.any_click() && !response.rect.contains(i.pointer.interact_pos().unwrap_or_default())) {
+                                        app_data.show_profile_menu = false;
                                     }
-                                    if ui.button("Wallet").clicked() {
-                                        app_data.current_tab = AppTab::Profile;
-                                        app_data.current_profile_sub_view = ProfileSubView::Wallet;
-                                        ui.close();
-                                    }
-                                });
+                                }
                             }
                         });
                     });
 
                 if !app_data.is_logged_in {
                     if app_data.current_tab == AppTab::Home {
-                        login_view::draw_login_view(ui, &mut app_data, app_data_arc_clone, runtime_handle);
+                        login_view::draw_login_view(ui, &mut app_data, app_data_arc_clone.clone(), runtime_handle.clone());
                     }
                 } else {
                     match app_data.current_tab {
                         AppTab::Home => {
-                            home_view::draw_home_view(ui, ctx, &mut app_data, app_data_arc_clone, runtime_handle);
+                            home_view::draw_home_view(ui, ctx, &mut app_data, app_data_arc_clone.clone(), runtime_handle.clone(), &mut urls_to_load);
                         },
                         AppTab::Profile => {
                             // NEW: Sub-view matching
                             match app_data.current_profile_sub_view {
                                 ProfileSubView::Profile => {
-                                    profile_view::draw_profile_view(ui, ctx, &mut app_data, app_data_arc_clone, runtime_handle);
+                                    profile_view::draw_profile_view(ui, ctx, &mut app_data, app_data_arc_clone.clone(), runtime_handle.clone(), &mut urls_to_load);
                                 },
                                 ProfileSubView::Relays => {
-                                    relays_view::draw_relays_view(ui, &mut app_data, app_data_arc_clone, runtime_handle);
+                                    relays_view::draw_relays_view(ui, &mut app_data, app_data_arc_clone.clone(), runtime_handle.clone());
                                 },
                                 ProfileSubView::Wallet => {
-                                    wallet_view::draw_wallet_view(ui, &mut app_data, app_data_arc_clone, runtime_handle);
+                                    wallet_view::draw_wallet_view(ui, &mut app_data, app_data_arc_clone.clone(), runtime_handle.clone());
                                 },
                             }
                         },
-                        // All cases are handled, no fallback needed
+                        AppTab::ArticleView => {
+                            article_view::draw_article_view(ui, ctx, &mut app_data, app_data_arc_clone.clone(), runtime_handle.clone(), &mut urls_to_load);
+                        }
                     }
                 }
         });
+
+        // --- Image Loading Logic ---
+        let cache_db = app_data.cache_db.clone();
+        let mut still_to_load = Vec::new();
+        for (url_key, kind) in urls_to_load {
+            if let Some(image_bytes) = image_cache::load_from_lmdb(&cache_db, &url_key) {
+                if let Ok(mut dynamic_image) = image::load_from_memory(&image_bytes) {
+                    let (width, height) = match kind {
+                        ImageKind::Avatar => (32, 32),
+                        ImageKind::Emoji => (20, 20),
+                        ImageKind::ProfilePicture => (100, 100),
+                    };
+                    dynamic_image = dynamic_image.thumbnail(width, height);
+                    let color_image = egui::ColorImage::from_rgba_unmultiplied(
+                        [dynamic_image.width() as usize, dynamic_image.height() as usize],
+                        dynamic_image.to_rgba8().as_flat_samples().as_slice(),
+                    );
+                    let texture_handle = ctx.load_texture(
+                        &url_key,
+                        color_image,
+                        Default::default()
+                    );
+                    app_data.image_cache.insert(url_key, ImageState::Loaded(texture_handle));
+                } else {
+                    app_data.image_cache.insert(url_key, ImageState::Failed);
+                }
+            } else {
+                still_to_load.push((url_key, kind));
+            }
+        }
+
+        let data_clone = self.data.clone();
+        for (url_key, kind) in still_to_load {
+            app_data.image_cache.insert(url_key.clone(), ImageState::Loading);
+            app_data.should_repaint = true;
+            let app_data_clone = data_clone.clone();
+            let ctx_clone = ctx.clone();
+            let cache_db_for_fetch = app_data.cache_db.clone();
+            let request = ehttp::Request::get(&url_key);
+            ehttp::fetch(request, move |result| {
+                let new_state = match result {
+                    Ok(response) => {
+                        if response.ok {
+                            image_cache::save_to_lmdb(&cache_db_for_fetch, &response.url, &response.bytes);
+                            match image::load_from_memory(&response.bytes) {
+                                Ok(mut dynamic_image) => {
+                                    let (width, height) = match kind {
+                                        ImageKind::Avatar => (32, 32),
+                                        ImageKind::Emoji => (20, 20),
+                                        ImageKind::ProfilePicture => (100, 100),
+                                    };
+                                    dynamic_image = dynamic_image.thumbnail(width, height);
+                                    let color_image = egui::ColorImage::from_rgba_unmultiplied(
+                                        [dynamic_image.width() as usize, dynamic_image.height() as usize],
+                                        dynamic_image.to_rgba8().as_flat_samples().as_slice(),
+                                    );
+                                    let texture_handle = ctx_clone.load_texture(
+                                        &response.url,
+                                        color_image,
+                                        Default::default()
+                                    );
+                                    ImageState::Loaded(texture_handle)
+                                }
+                                Err(_) => ImageState::Failed,
+                            }
+                        } else {
+                            ImageState::Failed
+                        }
+                    }
+                    Err(_) => ImageState::Failed,
+                };
+                let mut app_data = app_data_clone.lock().unwrap();
+                app_data.image_cache.insert(url_key, new_state);
+                ctx_clone.request_repaint();
+            });
+        }
 
         // update メソッドの最後に should_repaint をチェックし、再描画をリクエスト
         if app_data.should_repaint {

--- a/src/ui/article_view.rs
+++ b/src/ui/article_view.rs
@@ -1,0 +1,61 @@
+use eframe::egui;
+use std::sync::{Arc, Mutex};
+use nostr::prelude::ToBech32;
+
+use crate::types::*;
+
+pub fn draw_article_view(
+    ui: &mut egui::Ui,
+    _ctx: &egui::Context,
+    app_data: &mut NostrStatusAppInternal,
+    _app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    _runtime_handle: tokio::runtime::Handle,
+    _urls_to_load: &mut Vec<(String, ImageKind)>,
+) {
+    if let Some(post) = &app_data.viewing_article {
+        // Back button
+        if ui.button("← Back").clicked() {
+            app_data.viewing_article = None;
+            app_data.current_tab = AppTab::Home;
+            return;
+        }
+        ui.separator();
+        ui.add_space(10.0);
+
+        egui::ScrollArea::vertical().show(ui, |ui| {
+            // Constrain the width for readability
+            ui.set_max_width(700.0);
+
+            // Big Title
+            ui.heading(&post.title);
+            ui.add_space(5.0);
+
+            // Author info
+            ui.horizontal(|ui| {
+                // Simplified author display for now
+                let display_name = if !post.author_metadata.name.is_empty() {
+                    post.author_metadata.name.clone()
+                } else {
+                    let pubkey = post.author_pubkey.to_bech32().unwrap_or_default();
+                    format!("{}...{}", &pubkey[0..8], &pubkey[pubkey.len()-4..])
+                };
+                ui.label("by");
+                ui.label(egui::RichText::new(display_name).strong());
+            });
+            ui.add_space(15.0);
+            ui.separator();
+            ui.add_space(15.0);
+
+            // Full Content
+            // For now, just a simple label. Could be extended with Markdown rendering.
+            ui.label(&post.content);
+        });
+
+    } else {
+        // This case should ideally not be reached if logic is correct
+        ui.label("No article selected.");
+        if ui.button("Go Home").clicked() {
+            app_data.current_tab = AppTab::Home;
+        }
+    }
+}


### PR DESCRIPTION
This commit implements a dedicated view for reading full articles and refactors the main UI to use a dynamic user avatar for the profile menu.

- A new `article_view` module is created to display the full content of a selected article in a readable layout.
- The article cards on the home screen are now clickable, transitioning the application to this new view.
- The static profile icon in the top bar is replaced with the user's actual avatar, loaded asynchronously. The icon size is increased for better visibility.
- The `ImageButton` for the avatar opens a popup menu for Profile, Relays, and Wallet, improving UI consolidation.
- The underlying state management in `types.rs` and `ui.rs` is updated to support these new features, including a new `AppTab::ArticleView` and state fields for the article being viewed and the profile menu's visibility.
- Image loading logic is refactored from individual views and centralized in the main `ui.rs` update loop.