### PR TITLE
Implements caching for NIP-23 long-form content to improve UX.

### DIFF
--- a/src/cache_db.rs
+++ b/src/cache_db.rs
@@ -13,6 +13,7 @@ pub const DB_FOLLOWED: &str = "followed_pubkeys";
 pub const DB_RELAYS: &str = "nip65_relays";
 pub const DB_TIMELINE: &str = "timeline_posts";
 pub const DB_IMAGES: &str = "images";
+pub const DB_ARTICLES: &str = "articles";
 
 #[derive(Clone)]
 pub struct LmdbCache {
@@ -24,7 +25,7 @@ impl LmdbCache {
         std::fs::create_dir_all(path)?;
         let mut options = heed::EnvOpenOptions::new();
         options.map_size(1024 * 1024 * 1024); // 1 GB
-        options.max_dbs(8);
+        options.max_dbs(10);
         let env = unsafe { options.open(path)? };
 
         let mut txn = env.write_txn()?;
@@ -33,6 +34,7 @@ impl LmdbCache {
         let _: Database<Str, Bytes> = env.create_database(&mut txn, Some(DB_RELAYS))?;
         let _: Database<Str, Bytes> = env.create_database(&mut txn, Some(DB_TIMELINE))?;
         let _: Database<Str, Bytes> = env.create_database(&mut txn, Some(DB_IMAGES))?;
+        let _: Database<Str, Bytes> = env.create_database(&mut txn, Some(DB_ARTICLES))?;
         txn.commit()?;
 
         Ok(Self { env: Arc::new(env) })

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,7 @@ impl NostrStatusApp {
             show_zap_dialog: false,
             zap_amount_input: String::new(),
             zap_target_post: None,
+            viewing_article_id: None,
             viewing_article: None,
             show_profile_menu: false,
             commonmark_cache: CommonMarkCache::default(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -95,6 +95,19 @@ pub struct TimelinePost {
     pub author_pubkey: PublicKey,
     pub author_metadata: ProfileMetadata,
     pub title: String,
+    pub summary: String,
+    pub created_at: Timestamp,
+    #[serde(default)]
+    pub tags: Vec<nostr::Tag>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ArticleFull {
+    pub id: EventId,
+    pub kind: Kind,
+    pub author_pubkey: PublicKey,
+    pub author_metadata: ProfileMetadata,
+    pub title: String,
     pub content: String,
     pub created_at: Timestamp,
     #[serde(default)]
@@ -187,7 +200,8 @@ pub struct NostrStatusAppInternal {
     pub zap_amount_input: String,
     pub zap_target_post: Option<TimelinePost>,
     // Article View
-    pub viewing_article: Option<TimelinePost>,
+    pub viewing_article_id: Option<EventId>,
+    pub viewing_article: Option<ArticleFull>,
     // UI State
     pub show_profile_menu: bool,
     pub commonmark_cache: CommonMarkCache,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -15,9 +15,46 @@ use crate::{
     types::*,
 };
 
+use crate::nostr_client;
+
 impl eframe::App for NostrStatusApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         let mut app_data = self.data.lock().unwrap();
+
+        // --- Article Fetching Logic ---
+        if let Some(event_id) = app_data.viewing_article_id {
+            if app_data.viewing_article.is_none() && !app_data.is_loading {
+                app_data.is_loading = true;
+                app_data.should_repaint = true;
+
+                let app_data_arc = self.data.clone();
+                let runtime = self.runtime.handle().clone();
+                runtime.spawn(async move {
+                    let (cache_db, client) = {
+                        let data = app_data_arc.lock().unwrap();
+                        (data.cache_db.clone(), data.nostr_client.as_ref().unwrap().clone())
+                    };
+
+                    let result = nostr_client::fetch_article(&cache_db, &client, event_id).await;
+
+                    let mut data = app_data_arc.lock().unwrap();
+                    match result {
+                        Ok(article) => {
+                            data.viewing_article = Some(article);
+                        }
+                        Err(e) => {
+                            eprintln!("Failed to fetch article: {}", e);
+                            // Optionally, reset the view or show an error
+                            data.viewing_article_id = None;
+                            data.current_tab = AppTab::Home;
+                        }
+                    }
+                    data.is_loading = false;
+                    data.should_repaint = true;
+                });
+            }
+        }
+
 
         let home_tab_text = "ホーム";
 

--- a/src/ui/article_view.rs
+++ b/src/ui/article_view.rs
@@ -52,9 +52,18 @@ pub fn draw_article_view(
         });
 
     } else {
-        // This case should ideally not be reached if logic is correct
-        ui.label("No article selected.");
-        if ui.button("Go Home").clicked() {
+        // Article is being loaded, show a spinner
+        ui.vertical_centered(|ui| {
+            ui.add_space(ui.available_height() / 2.0 - 20.0); // Center vertically
+            ui.spinner();
+            ui.add_space(10.0);
+            ui.label("記事を読み込んでいます...");
+        });
+
+        // Also provide a way to go back if it gets stuck
+        if ui.button("← Back").clicked() {
+            app_data.viewing_article_id = None;
+            app_data.viewing_article = None;
             app_data.current_tab = AppTab::Home;
         }
     }

--- a/src/ui/login_view.rs
+++ b/src/ui/login_view.rs
@@ -108,7 +108,7 @@ async fn fetch_fresh_data_from_network(
         cache_db.write_cache(DB_FOLLOWED, &pubkey_hex, &followed_pubkeys)?;
     }
 
-    let timeline_posts = fetch_timeline_events(keys, discover_relays, &followed_pubkeys).await?;
+    let timeline_posts = fetch_timeline_events(keys, discover_relays, &followed_pubkeys, cache_db).await?;
     cache_db.write_cache(DB_TIMELINE, &pubkey_hex, &timeline_posts)?;
 
     let (profile_metadata, profile_json_string) =


### PR DESCRIPTION
This change introduces a caching layer for articles (NIP-23 events). The timeline view now only loads and displays a summary of each article, significantly reducing initial load time and memory usage.

When a user clicks on an article, the full content is fetched on-demand from the cache. If the article is not in the cache or has expired, it is fetched from the network and then stored in the cache for future use.

The article view now also displays a loading indicator while the content is being fetched.

Changes include:
- Added a new 'articles' database to the LMDB cache.
- Modified data structures to distinguish between full articles and timeline summaries.
- Updated the nostr client to handle the caching and on-demand fetching logic.
- Adjusted the UI to reflect these changes, including the timeline view, article view, and the main UI loop.